### PR TITLE
feat: dodani soft deletes

### DIFF
--- a/Backend/app/Models/KorisnikPodatak.php
+++ b/Backend/app/Models/KorisnikPodatak.php
@@ -4,11 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class KorisnikPodatak extends Model
 {
     protected $table = 'korisnikPodatak';
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = [
         'Odgovor',

--- a/Backend/app/Models/ListaPrijava.php
+++ b/Backend/app/Models/ListaPrijava.php
@@ -4,11 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class ListaPrijava extends Model
 {
     protected $table = 'listaPrijava';
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = [
         'IdKreatora',

--- a/Backend/app/Models/PitanjaRadionice.php
+++ b/Backend/app/Models/PitanjaRadionice.php
@@ -4,12 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class PitanjaRadionice extends Model
 {
     protected $table = 'pitanjaRadionice';
-
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = [
         'NazivPitanja',

--- a/Backend/app/Models/Radionica.php
+++ b/Backend/app/Models/Radionica.php
@@ -4,10 +4,11 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Radionica extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     protected $table = 'radionica';
 

--- a/Backend/app/Models/User.php
+++ b/Backend/app/Models/User.php
@@ -4,13 +4,14 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable, SoftDeletes;
 
     /**
      * The attributes that are mass assignable.

--- a/Backend/database/migrations/2025_04_10_193145_add_deleted_at_to_all_models.php
+++ b/Backend/database/migrations/2025_04_10_193145_add_deleted_at_to_all_models.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	/**
+	 * Run the migrations.
+	 */
+	public function up(): void
+	{
+		Schema::table('users', function (Blueprint $table) {
+			$table->softDeletes();
+		});
+		Schema::table('radionica', function (Blueprint $table) {
+			$table->softDeletes();
+		});
+		Schema::table('pitanjaRadionice', function (Blueprint $table) {
+			$table->softDeletes();
+		});
+		Schema::table('listaPrijava', function (Blueprint $table) {
+			$table->softDeletes();
+		});
+		Schema::table('korisnikPodatak', function (Blueprint $table) {
+			$table->softDeletes();
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void
+	{
+		Schema::table('users', function (Blueprint $table) {
+			$table->dropSoftDeletes();
+		});
+		Schema::table('radionica', function (Blueprint $table) {
+			$table->dropSoftDeletes();
+		});
+		Schema::table('pitanjaRadionice', function (Blueprint $table) {
+			$table->dropSoftDeletes();
+		});
+		Schema::table('listaPrijava', function (Blueprint $table) {
+			$table->dropSoftDeletes();
+		});
+		Schema::table('korisnikPodatak', function (Blueprint $table) {
+			$table->dropSoftDeletes();
+		});
+	}
+};


### PR DESCRIPTION
Dodani soft deletes putem Eloquent `SoftDeletes` traita.

Za testiranje:
1. `GET /Radionice` -> dobiju se sve radionice
2. `DELETE /Radionice/2` -> uspjesno se izbrise radionica sa id-em 2
3. `GET /Radionice` -> dobiju se sve radionice osim radionice sa id-em 2
4. Udjemo u MySQL container i izlistamo sve radionice putem mysql CLI:
   ```bash
   docker exec -it prijave-mysql bash
   mysql -u prijave -pprijave
   use prijave;
   select * from radionica order by id asc limit 5;
   ```
   Unutar baze, radionica sa id-em 2 je jos uvijek tu. Njen `deleted_at` stupac je stavljen na danasnji datum, dok ostalim (neizbrisanim) retcima je taj stupac null.